### PR TITLE
Add Apache static export configuration

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,76 @@
+# 🚀 Deployment na Apache Server
+
+Tento projekt je nakonfigurován pro generování statických souborů, které můžete nahrát na jakýkoli Apache hosting.
+
+## 📦 Generování statických souborů
+
+```bash
+# Vygeneruje statické soubory
+make export
+```
+
+Nebo přímo:
+```bash
+npm run build
+```
+
+## 📁 Soubory pro upload
+
+Po spuštění `make export` najdete všechny potřebné soubory v adresáři `out/`:
+
+```
+out/
+├── index.html          # Hlavní stránka
+├── 404.html           # Error stránka
+├── _next/             # Next.js assets (CSS, JS)
+├── .htaccess          # Apache konfigurace
+└── ostatní soubory...
+```
+
+## 🔧 Nahrání na Apache server
+
+1. **Vygenerujte soubory**: `make export`
+2. **Nahrajte obsah `out/` adresáře** na váš Apache server (do root adresáře webu)
+3. **Ujistěte se**, že `.htaccess` soubor je nahrán a Apache má povolený `mod_rewrite`
+
+## ⚙️ Apache konfigurace
+
+Projekt obsahuje `.htaccess` soubor, který zajišťuje:
+
+- ✅ **Client-side routing** - SPA funguje správně
+- ✅ **Komprese** - rychlejší načítání
+- ✅ **Cache headers** - optimalizace výkonu  
+- ✅ **Security headers** - základní zabezpečení
+
+### Požadavky na Apache:
+- `mod_rewrite` (pro routing)
+- `mod_deflate` (pro kompresi) - volitelné
+- `mod_expires` (pro cache) - volitelné
+- `mod_headers` (pro security) - volitelné
+
+## 🌐 Testování
+
+Po nahrání můžete otestovat:
+
+1. Otevřete hlavní URL vašeho webu
+2. Zkuste refresh stránky (měl by fungovat díky `.htaccess`)
+3. Zkontrolujte, že všechny assets se načítají správně
+
+## 🔄 Aktualizace
+
+Pro aktualizaci webu:
+
+1. Proveďte změny v kódu
+2. Spusťte `make export`
+3. Nahrajte nový obsah `out/` adresáře na server
+
+## 🐛 Řešení problémů
+
+**Problém**: 404 chyba při refreshi stránky
+**Řešení**: Ujistěte se, že `.htaccess` je nahrán a `mod_rewrite` je povolen
+
+**Problém**: Soubory se nenačítají
+**Řešení**: Zkontrolujte cesty k souborům a ujistěte se, že jsou všechny soubory z `out/` nahrány
+
+**Problém**: Styling nefunguje
+**Řešení**: Zkontrolujte, že se načítají CSS soubory z `_next/static/` adresáře

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Age Calculator - Makefile
 
-.PHONY: help install dev build start test lint clean
+.PHONY: help install dev build start test lint clean export
 
 # Default target
 help:
@@ -10,6 +10,7 @@ help:
 	@echo "  make install  - Nainstaluje závislosti"
 	@echo "  make dev      - Spustí vývojový server"
 	@echo "  make build    - Sestaví produkční verzi"
+	@echo "  make export   - Vygeneruje statické soubory pro Apache"
 	@echo "  make start    - Spustí produkční server"
 	@echo "  make test     - Spustí testy"
 	@echo "  make lint     - Zkontroluje kód"
@@ -29,6 +30,12 @@ dev:
 build:
 	@echo "🏗️ Sestavuji produkční verzi..."
 	npm run build
+
+# Export static files for Apache
+export: build
+	@echo "📦 Generuji statické soubory pro Apache..."
+	@echo "✅ Statické soubory jsou v adresáři 'out/'"
+	@echo "📁 Nahrajte obsah 'out/' adresáře na váš Apache server"
 
 # Start production server
 start: build

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'export',
+  trailingSlash: true,
+  images: {
+    unoptimized: true
+  }
 };
 
 export default nextConfig;

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,42 @@
+# Apache configuration for Next.js static export
+RewriteEngine On
+
+# Handle client-side routing
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ /index.html [L]
+
+# Enable compression
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE text/plain
+    AddOutputFilterByType DEFLATE text/html
+    AddOutputFilterByType DEFLATE text/xml
+    AddOutputFilterByType DEFLATE text/css
+    AddOutputFilterByType DEFLATE application/xml
+    AddOutputFilterByType DEFLATE application/xhtml+xml
+    AddOutputFilterByType DEFLATE application/rss+xml
+    AddOutputFilterByType DEFLATE application/javascript
+    AddOutputFilterByType DEFLATE application/x-javascript
+</IfModule>
+
+# Set cache headers
+<IfModule mod_expires.c>
+    ExpiresActive on
+    ExpiresByType text/css "access plus 1 year"
+    ExpiresByType application/javascript "access plus 1 year"
+    ExpiresByType image/png "access plus 1 year"
+    ExpiresByType image/jpg "access plus 1 year"
+    ExpiresByType image/jpeg "access plus 1 year"
+    ExpiresByType image/gif "access plus 1 year"
+    ExpiresByType image/svg+xml "access plus 1 year"
+    ExpiresByType image/webp "access plus 1 year"
+    ExpiresByType font/woff "access plus 1 year"
+    ExpiresByType font/woff2 "access plus 1 year"
+</IfModule>
+
+# Security headers
+<IfModule mod_headers.c>
+    Header always set X-Content-Type-Options nosniff
+    Header always set X-Frame-Options DENY
+    Header always set X-XSS-Protection "1; mode=block"
+</IfModule>


### PR DESCRIPTION
- Configure Next.js for static export with output: 'export'
- Add trailingSlash and unoptimized images for static hosting
- Add 'make export' command to Makefile
- Create .htaccess with Apache configuration for SPA routing
- Add compression, caching, and security headers
- Create DEPLOYMENT.md with detailed Apache deployment instructions
- Static files are generated in 'out/' directory ready for upload